### PR TITLE
fix: resolve duplicate __init__ in DeepTalkLogger

### DIFF
--- a/src/deeptalk_logger.py
+++ b/src/deeptalk_logger.py
@@ -28,10 +28,7 @@ logging.basicConfig(
 )
 
 class DeepTalkLogger:
-    def __init__(self):
-        self.logger = logging.getLogger()
-
-    def __init__(self, name: str):
+    def __init__(self, name: str = ""):
         self.logger = logging.getLogger(name)
 
     def debug(self, msg, *args, **kwargs):


### PR DESCRIPTION
## Summary

Fixed duplicate __init__ methods in DeepTalkLogger class.

## Changes

- Combined two __init__ methods into one with default parameter name: str = ""
- Now supports both DeepTalkLogger() and DeepTalkLogger("name") calls

Fixes huyyxy/DeepTalk-ASD#10