### PR TITLE
fix: check _state is None before use in SileroVAD

### DIFF
--- a/src/turn_detector/vad/silero_vad.py
+++ b/src/turn_detector/vad/silero_vad.py
@@ -68,6 +68,9 @@ class SileroVAD:
             raise ValueError(f"Expected {CHUNK} samples, got {x.shape[1]}")
         x = np.concatenate((self._context, x), axis=1)
 
+        if self._state is None:
+            self._init_states()
+
         ort_inputs = {
             "input": x.astype(np.float32),
             "state": self._state,


### PR DESCRIPTION
## Summary

Fixed potential None state issue in SileroVAD._prob_chunk().

## Changes

- Added check for _state being None before using it
- Calls _init_states() if _state is None

Fixes huyyxy/DeepTalk-ASD#9