### PR TITLE
fix: clear prefix_buffer in _reset

### DIFF
--- a/src/turn_detector/silero_vad_turn_detector.py
+++ b/src/turn_detector/silero_vad_turn_detector.py
@@ -79,7 +79,8 @@ class SileroVadTurnDetector(TurnDetectorInterface):
         self._voice_duration_ms = 0
         self._silence_duration_ms_acc = 0
         self._is_confirmed = False
-        # 注意: _prefix_buffer 不在此处清空，保持滚动缓冲
+        # 清空前置缓冲区，避免旧数据影响新的语音段
+        self._prefix_buffer.clear()
 
     def detect(self, audio_frame: AudioFrame) -> Utterance:
         """根据输入的音频帧，检测轮次信息


### PR DESCRIPTION
## Summary

Fixed prefix buffer not being cleared in _reset().

## Changes

- Added _prefix_buffer.clear() in _reset method
- Prevents old prefix frames from polluting new speech segments

Fixes huyyxy/DeepTalk-ASD#8