### PR TITLE
fix: use constant padding instead of wrap

### DIFF
--- a/src/speaker_detector/lrasd_onnx.py
+++ b/src/speaker_detector/lrasd_onnx.py
@@ -276,7 +276,8 @@ class LRASDOnnxSpeakerDetector(SpeakerDetectorInterface):
                         audio_chunk = np.pad(
                             audio_chunk,
                             ((0, target_a_len - audio_chunk.shape[0]), (0, 0)),
-                            'wrap',
+                            'constant',
+                            constant_values=0,
                         )
                     audio_chunk = audio_chunk[:target_a_len, :]
 


### PR DESCRIPTION
## Summary

Fixed audio padding mode in LRASDOnnxSpeakerDetector.

## Changes

- Changed np.pad mode from wrap to constant
- Pads with zeros instead of wrapping audio data
- More appropriate for speech processing

Fixes huyyxy/DeepTalk-ASD#7